### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/USCISApplications/data/questions/change_venue_address.yml
+++ b/docassemble/USCISApplications/data/questions/change_venue_address.yml
@@ -261,7 +261,7 @@ attachment:
     # - "practitioner_email": ${ representative.email }
     # - "practitioner_phone": ${ phone_number_formatted(representative.fax_number) }
     # Page 2
-    - "users1_full_name": ${ users[i].name.full(middle="full") }
+    - "users1_full_name": ${ users[i].name_full() }
     - "pos_date": ${ today().format('MM/dd/yyyy') }
     - "pos_dhs_address_full": ${ users[i].dhs.address.on_one_line(bare=True) }
 
@@ -285,7 +285,7 @@ attachment:
   editable: False
   fields:
 
-    - "users1_name": ${ users[i].name.full(middle="full") }
+    - "users1_name": ${ users[i].name_full() }
     - "users1_a_number": ${ users[i].a_number }
     - "care_name_current": ''
     - "care_name_former": ''

--- a/docassemble/USCISApplications/data/questions/combined_application_questions.yml
+++ b/docassemble/USCISApplications/data/questions/combined_application_questions.yml
@@ -2886,7 +2886,7 @@ attachment:
     - "is_other_marital_status": ${ users[i].marital_status == 'other' }
     - "marital_status_other_explanation": ${ users[i].marital_status_other }
     # Part 4
-    - "users1_name": ${ users[i].name.full(middle="full") }
+    - "users1_name": ${ users[i].name_full() }
     - "forms_filed": |
         % if application_kind == "ead_only":
         I-765

--- a/docassemble/USCISApplications/data/questions/main.yml
+++ b/docassemble/USCISApplications/data/questions/main.yml
@@ -603,7 +603,7 @@ table: users.initial_review_table
 rows: users
 columns:
   - Name: |
-      row_item.name.full(middle="full")
+      row_item.name_full()
   - Country of birth: |
       row_item.country_of_birth
   - City of birth: |
@@ -1386,7 +1386,7 @@ attachment:
   skip undefined: True
   editable: False
   fields:
-    - "document_set_for": ${ users[i].name.full(middle="full") }
+    - "document_set_for": ${ users[i].name_full() }
 ---
 attachment:
   variable name: users[i].ending_page[j]
@@ -1396,4 +1396,4 @@ attachment:
   skip undefined: True
   editable: False
   fields:
-    - "document_set_for": ${ users[i].name.full(middle="full") }
+    - "document_set_for": ${ users[i].name_full() }

--- a/docassemble/USCISApplications/data/questions/review_screen.yml
+++ b/docassemble/USCISApplications/data/questions/review_screen.yml
@@ -25,7 +25,7 @@ review:
 
       &nbsp; | &nbsp;
       -------|-------
-      Name | ${ users[i].name.full(middle="full") }
+      Name | ${ users[i].name_full() }
       Birthplace | ${ showifdef("users[i].city_of_birth")}, ${ showifdef("users[i].state_of_birth") } ${ showifdef("users[i].country_of_birth") }
       Date of birth | ${ users[i].birthdate }, age ${ users[i].age_in_years() }
       A-number | ${ users[i].a_number }


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>